### PR TITLE
"menu.phone.jsのメニュー開閉部分の調整、余白の微調整"

### DIFF
--- a/src/components/ui_parts/header/menu/menu.phone.js
+++ b/src/components/ui_parts/header/menu/menu.phone.js
@@ -25,11 +25,11 @@ const toScrollable = () => {
 const onClickMenuButton = () => {
   toggleDisplay(menuButtonOpen);
   toggleDisplay(menuButtonClose);
-  expandedMenu.classList.toggle('fixed');
+  expandedMenu.classList.toggle('absolute');
   expandedMenu.classList.toggle('hidden');
 
   // スクロール制御
-  const isOpen = expandedMenu.classList.contains('fixed');
+  const isOpen = expandedMenu.classList.contains('absolute');
   isOpen ? disableScroll() : toScrollable();
 };
 

--- a/src/components/ui_parts/header/menu/menu.phone.php
+++ b/src/components/ui_parts/header/menu/menu.phone.php
@@ -1,7 +1,7 @@
 <?php
 // スマホ用メニュー開くボタン
 ?>
-<div id="menuButtonOpen" class="flex flex-col justify-evenly px-1 w-10 h-10 border border-primary-light rounded cursor-pointer">
+<div id="menuButtonOpen" class="flex flex-col justify-evenly px-1 w-10 h-10 border border-primary-light rounded cursor-pointer ">
   <?php for ($i = 0; $i < 3; $i++) { ?>
     <hr class=" border-primary-light" />
   <?php } ?>
@@ -17,23 +17,21 @@
 <?php
 // スマホ用メニューをクリック時に展開されるメニュー
 ?>
-<div id="expandedMenu" class="hidden top-24 left-0 z-50">
-  <div class="h-screen w-screen bg-primary-dark p-4">
-    <ul class="flex flex-col gap-4 [&_li]:text-white [&_li]:border-b [&_li]:border-white [&_li]:py-2 ">
-      <li>
-        <a href="facility"> 施設概要 </a>
-      </li>
-      <li>
-        <a href="rental"> レンタル用品 </a>
-      </li>
-      <li>
-        <a href="#"> スタッフ紹介 </a>
-      </li>
-      <li>
-        <a href="#"> アクセス </a>
-      </li>
-    </ul>
-  </div>
+<div id="expandedMenu" class="hidden top-24 left-0 z-50 bg-primary-dark h-screen w-screen px-4">
+  <ul class="flex flex-col  [&_li]:text-white [&_li]:border-b [&_li]:border-white [&_li]:py-4">
+    <li>
+      <a href="facility"> 施設概要 </a>
+    </li>
+    <li>
+      <a href="rental"> レンタル用品 </a>
+    </li>
+    <li>
+      <a href="#"> スタッフ紹介 </a>
+    </li>
+    <li>
+      <a href="#"> アクセス </a>
+    </li>
+  </ul>
 </div>
 
 <script src="<?php echo $absoluteUriPath . "/components/ui_parts/header/menu/menu.phone.js" ?>"></script>


### PR DESCRIPTION
<!-- #の直後にIssue番号 -->
Close #

## 概要
スマホ用メニュー実装の調整
## やったこと
js内のメニュー開閉部分、PositionをFixedからAbsoluteに変更
余白の微調整
## やらなかったこと

## 備考
<!-- 参考にした資料や記事あれば -->
https://kouhekikyozou.com/css_position_fixed_error#%EF%BC%93%EF%BC%8D%EF%BC%92%EF%BC%8Etransform%E4%BB%A5%E5%A4%96%E3%81%AE%E6%96%B9%E6%B3%95%E3%81%A7%E5%90%8C%E3%81%98%E5%8B%95%E4%BD%9C%E3%81%8C%E5%8F%AF%E8%83%BD%E3%81%8B%E6%8E%A2%E3%82%8B

https://coliss.com/articles/build-websites/operation/css/css-position-sticky-how-it-really-works.html

上記の2サイトなどを参考にposition-fixedがうまく動いてないと判断して、absoluteに変更してみたらいけました。勘というかいじってたらいけた感じで、正直何がサイトの言ってることもうまくいってなかった原因もあんまり理解できてないです！判断お願いします🙇‍♂️